### PR TITLE
Fix: Updated parseQueryParam splitter to fix bug in time ISOString parsing

### DIFF
--- a/sequelizeQueryParser.js
+++ b/sequelizeQueryParser.js
@@ -175,7 +175,7 @@ module.exports = function (db) {
      * @returns {string|JSON} sequelize formatted DB query param
      */
     const parseQueryParam = (query) => {
-        let elements = query.split(':');
+        let elements = query.split(/:(.+)/);
         // console.debug("Query param: ", JSON.stringify(elements, null, 4));
         if (elements && elements.length > 1) {
             var param = {};

--- a/sequelizeQueryParser.js
+++ b/sequelizeQueryParser.js
@@ -179,15 +179,20 @@ module.exports = function (db) {
         // console.debug("Query param: ", JSON.stringify(elements, null, 4));
         if (elements && elements.length > 1) {
             var param = {};
-            param[operators[elements[0]]] = elements[1]
-    
-            // console.debug("Query param: ", param);
-            return param;
+            const elementsArray = elements[1].split(',')
+            if (elementsArray){
+                if (elementsArray.length > 1){
+                    param[operators[elements[0]]] = elementsArray
+                }
+                else {
+                    param[operators[elements[0]]] = elementsArray[0]
+                }
+                // console.debug("Query param: ", param);
+                return param;
+            }
         }
-        else {
-            // console.debug("Query param: ", elements[0]);
-            return elements[0];
-        }
+        // console.debug("Query param: ", elements[0]);
+        return elements[0];
     }
     
     // Max page size limit is set to 200


### PR DESCRIPTION
I found a problem passing time ISOString like  **2021-09-27T13:50:26.947Z**.

Consider a simple query like **?createdAt=gt:2021-09-27T13:50:26.947Z**. 
Using  **:** as splitter cause the string to be split in  ["gt", "2021-09-27T13", "50", "26.947Z"] and interpreted as 
`
 where: { createdAt: { [Symbol(gt)]: '2021-09-27T13' } }
`
The worst case is when you use between operator and an array of ISOStrings.  
For example **?createdAt=between:2021-09-27T13:50:26.947Z,2021-09-27T14:50:26.947Z**  is interpreted as
`
 where: { createdAt: { [Symbol(between)]: '2021-09-27T13' } }
`
causing query to crash.

Using the RegExp **/:(.+)/** ensures that the string is split at first **:** occurrence  and solve the problem.

I have also added array parsing in simple filters, so that the values are correct parsed when the between operator is used.